### PR TITLE
v4l-test-app: support AV1 decoding

### DIFF
--- a/IrisTestApp.cpp
+++ b/IrisTestApp.cpp
@@ -31,16 +31,11 @@
 
 uint32_t gLogLevel = 0xF;
 
-std::unordered_map<std::string, std::string> gCodecMap = {
-    {"AVC", "VIDEO_CodingAVC"},
-    {"VP9", "VIDEO_CodingVP9"},
-    {"HEVC", "VIDEO_CodingHEVC"},
-};
-
 std::unordered_map<std::string, unsigned int> gCodecIDMap = {
     {"AVC", V4L2_PIX_FMT_H264},
     {"VP9", V4L2_PIX_FMT_VP9},
     {"HEVC", V4L2_PIX_FMT_HEVC},
+    {"AV1", V4L2_PIX_FMT_AV1},
 };
 
 std::unordered_map<std::string, unsigned int> gColorFormatIDMap = {

--- a/inc/Log.h
+++ b/inc/Log.h
@@ -9,6 +9,8 @@
 #define _LOG_H_
 
 #include <stdio.h>
+#include <stdint.h>
+
 #include <iostream>
 
 extern uint32_t gLogLevel;

--- a/inc/V4l2Driver.h
+++ b/inc/V4l2Driver.h
@@ -60,6 +60,10 @@ enum v4l2_mpeg_video_intra_refresh_period_type {
 #define V4L2_PIX_FMT_QC10C                                  v4l2_fourcc('Q', '1', '0', 'C')
 #endif
 
+#ifndef V4L2_PIX_FMT_AV1
+#define V4L2_PIX_FMT_AV1                                    v4l2_fourcc('A', 'V', '1', '0')
+#endif
+
 #define INPUT_MPLANE V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE
 #define OUTPUT_MPLANE V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE
 

--- a/src/FFStreamParser.cpp
+++ b/src/FFStreamParser.cpp
@@ -10,6 +10,7 @@
 #include <ctime>
 #include <iostream>
 
+#include "V4l2Driver.h"
 #include "FFStreamParser.h"
 
 FFStreamParser::FFStreamParser(std::string inputPath, std::string sessionId)
@@ -88,6 +89,9 @@ int FFStreamParser::init() {
             break;
         case AV_CODEC_ID_VP9:
             mCodecFmt = V4L2_PIX_FMT_VP9;
+            break;
+        case AV_CODEC_ID_AV1:
+            mCodecFmt = V4L2_PIX_FMT_AV1;
             break;
         default:
             std::cerr << "[" << mSessionId << "]: Error: unsupported codec."


### PR DESCRIPTION
v4l-test-app: support AV1 decoding by adding Codec_ID to driver and parser module