### PR TITLE
v4l-test-app: allocate buffer with the min count

### DIFF
--- a/src/V4l2Decoder.cpp
+++ b/src/V4l2Decoder.cpp
@@ -123,14 +123,12 @@ int V4l2Decoder::configureInput() {
     LOGD("configureInput: width(%d),height(%d),stride(%d),inputSize(%d)\n",
         mWidth, mHeight, mStride, mInputSize);
 
-#if 0
     ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_OUTPUT;
     ret = mV4l2Driver->getControl(&ctrl);
     if (ret) {
         return ret;
     }
     mMinInputCount = ctrl.value;
-#endif
 
     if (mActualInputCount < mMinInputCount) {
         LOGD("update input count from %d to %d\n", mActualInputCount,
@@ -206,14 +204,12 @@ int V4l2Decoder::configureOutput() {
         return ret;
     }
 
-#if 0
     ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_CAPTURE;
     ret = mV4l2Driver->getControl(&ctrl);
     if (ret) {
         return ret;
     }
     mMinOutputCount = ctrl.value;
-#endif
 
     if (mActualOutputCount < mMinOutputCount) {
         LOGD("update output count from %d to %d\n", mActualOutputCount,

--- a/src/V4l2Encoder.cpp
+++ b/src/V4l2Encoder.cpp
@@ -294,14 +294,12 @@ int V4l2Encoder::configureInput() {
         mCropHeight = mHeight;
     }
 
-#if 0
     ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_OUTPUT;
     ret = mV4l2Driver->getControl(&ctrl);
     if (ret) {
         return ret;
     }
     mMinInputCount = ctrl.value;
-#endif
 
     if (mActualInputCount < mMinInputCount) {
         LOGV("update input count from %d to %d\n", mActualInputCount,
@@ -338,14 +336,12 @@ int V4l2Encoder::configureOutput() {
     }
     mOutputSize = fmt.fmt.pix_mp.plane_fmt[0].sizeimage;
 
-#if 0
     ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_CAPTURE;
     ret = mV4l2Driver->getControl(&ctrl);
     if (ret) {
         return ret;
     }
     mMinOutputCount = ctrl.value;
-#endif
 
     if (mActualOutputCount < mMinOutputCount) {
         LOGV("update output count from %d to %d\n", mActualOutputCount,


### PR DESCRIPTION
First query the driver for the minimum buffer count required, and then allocate buffers.

Change-Id: I0cb38d22ac5e2659a7af282894e98c4c16d1f1ff