### PR TITLE
CMakeLists.txt: fix invalid syntax in CMAKE_EXECUTABLE_ENABLE_EXPORTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_EXE_LINKER_FLAGS "-static")
-set(CMAKE_EXECUTABLE_ENABLE_EXPORTS, TRUE)
+set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)
 set(CMAKE_C_COMPILER /usr/aarch64-linux-gnu/bin/aarch64-none-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER /usr/aarch64-linux-gnu/bin/aarch64-none-linux-gnu-g++)
 


### PR DESCRIPTION
Remove stray comma  so that CMake correctly parses and applies the option to enable executable exports.