### PR TITLE
Fix build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,18 +15,16 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O2 -Wl,--no-as-needed")
 endif()
 
+find_package(jsoncpp REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(AVCODEC REQUIRED IMPORTED_TARGET GLOBAL libavcodec libavutil libavformat)
+
 
 # Include directories
 set(VIDC_TEST_INCLUDES
     inc/
-    third-parties/jsoncpp/output/include
-    third-parties/ffmpeg/output/include
 )
 include_directories(${VIDC_TEST_INCLUDES})
-link_directories(
-    third-parties/jsoncpp/output/lib
-    third-parties/ffmpeg/output/lib
-)
 
 set(VIDC_TEST_SOURCES
     IrisTestApp.cpp
@@ -41,4 +39,4 @@ set(VIDC_TEST_SOURCES
 )
 
 add_executable(iris_v4l2_test ${VIDC_TEST_SOURCES})
-target_link_libraries(iris_v4l2_test avformat avcodec swresample avutil pthread jsoncpp)
+target_link_libraries(iris_v4l2_test PkgConfig::AVCODEC pthread jsoncpp_lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,6 @@ project(iris_v4l2_test)
 # Compiler flags
 set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR aarch64)
-set(CMAKE_EXE_LINKER_FLAGS "-static")
-set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)
-set(CMAKE_C_COMPILER /usr/aarch64-linux-gnu/bin/aarch64-none-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER /usr/aarch64-linux-gnu/bin/aarch64-none-linux-gnu-g++)
-
 # Build debug version
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     message(STATUS "Debug mode")


### PR DESCRIPTION
Stop overriding CMake variables with the values specific for the one build environment. Use system tools and system locations for hte libs.